### PR TITLE
Links in event info

### DIFF
--- a/app/Http/Controllers/ClubEventController.php
+++ b/app/Http/Controllers/ClubEventController.php
@@ -226,6 +226,14 @@ class ClubEventController extends Controller
             return Redirect::action('MonthController@showMonth', array('year' => date('Y'), 
                                                                    'month' => date('m')));
         }
+
+        //ignore html tags in the info boxes
+        $clubEvent->evnt_public_info = htmlspecialchars($clubEvent->evnt_public_info, ENT_NOQUOTES);
+        $clubEvent->evnt_private_details = htmlspecialchars($clubEvent->evnt_private_details, ENT_NOQUOTES);
+
+        //if URL is in one of the info boxes, convert it to clickable hyperlink (<a> tag)
+        $clubEvent->evnt_public_info = $this->addLinks($clubEvent->evnt_public_info);
+        $clubEvent->evnt_private_details = $this->addLinks($clubEvent->evnt_private_details);
     
         $schedule = Schedule::findOrFail($clubEvent->getSchedule->id);
 
@@ -492,6 +500,21 @@ class ClubEventController extends Controller
         $event->evnt_show_to_club = json_encode($filter, true);
         
         return $event;
+    }
+
+    /**
+     * used to make URL's into hyperlinks using a <a> tag
+     * @param string $text
+     * @return string
+     */
+    private function addLinks($text) {
+        $text = preg_replace('$(https?://[a-z0-9_./?=&#-]+)(?![^<>]*>)$i',
+            ' <a href="$1" target="_blank">$1</a> ',
+            $text);
+        $text = preg_replace('$(www\.[a-z0-9_./?=&#-]+)(?![^<>]*>)$i',
+            '<a target="_blank" href="http://$1"  target="_blank">$1</a> ',
+            $text);
+        return $text;
     }
 
 }

--- a/resources/views/clubEventView.blade.php
+++ b/resources/views/clubEventView.blade.php
@@ -147,7 +147,7 @@
 			<div class="panel">
 				<div class="panel-body more-info">
 					<h5 class="panel-title">{{ trans('mainLang.additionalInfo') }}:</h5>
-					{!! nl2br(e($clubEvent->evnt_public_info)) !!}
+					{!! nl2br($clubEvent->evnt_public_info) !!}
 				</div>
 				<button type="button" class="moreless-more-info btn btn-primary btn-margin" data-dismiss="alert">{{ trans('mainLang.showMore') }}</button>
 				<button type="button" class="moreless-less-info btn btn-primary btn-margin" data-dismiss="alert">{{ trans('mainLang.showLess') }}</button>
@@ -159,7 +159,7 @@
 				<div class="panel hidden-print">
 					<div class="panel-body more-details">
 						<h5 class="panel-title">{{ trans('mainLang.moreDetails') }}:</h5>
-						{!! nl2br(e($clubEvent->evnt_private_details)) !!}
+						{!! nl2br($clubEvent->evnt_private_details) !!}
 					</div>
 					<button type="button" class="moreless-more-details btn btn-primary btn-margin" data-dismiss="alert">{{ trans('mainLang.showMore') }}</button>
 					<button type="button" class="moreless-less-details btn btn-primary btn-margin" data-dismiss="alert">{{ trans('mainLang.showLess') }}</button>


### PR DESCRIPTION
- added detection of links (www, http, https) and covering them in <a> tags in public and private event info
- still prevents the user from injecting HTML tags
- closes #39 
(basically same code used like that from softwareproject 2016)