### PR TITLE
Moved calls to check_question_type etc. to js scripts

### DIFF
--- a/public/js/surveyEdit-Create-scripts.js
+++ b/public/js/surveyEdit-Create-scripts.js
@@ -419,3 +419,15 @@ $('form').on( 'submit', function () {
         $('#required1_hidden').attr('checked', 'true');
 
 });
+
+$(function () {
+    // -1 for the cloned input hidden div
+    var amountOfQuestions =  $('div[id^=questions]').length - 1;
+    for(var i = 0; i < amountOfQuestions; i++) {
+        check_question_type(i);
+        check_question_type2(i);
+        setField(i);
+        setField2(i);
+    }
+
+});

--- a/resources/views/partials/surveyForm.blade.php
+++ b/resources/views/partials/surveyForm.blade.php
@@ -233,16 +233,6 @@
 
                         </div>
                 @endif
-
-                <span hidden>{{$counter2 = 0}}</span>
-                @if(isset($questions))
-                    @foreach($questions as $question)
-                        <script>
-                            check_question_type({{$counter2}}); check_question_type2({{$counter2}}); setField({{$counter2}}); setField2({{$counter2}});
-                        </script>
-                        <span hidden>{{++$counter2}}</span>
-                    @endforeach
-                @endif
             </div>
 
             <div class="create_survey">


### PR DESCRIPTION
#ref 182 
Previously editing questions would fail, because the blade template would try to call js functions before they were defined.